### PR TITLE
Add file-based word blacklisting

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -20,4 +20,4 @@ samplers = ["Euler a", "Euler", "DPM++ 2M Karras", "DPM++ SDE Karras", "DPM++ 2M
 
 [blacklist]
 words = ["nsfw", "nude", "naked", "pussy", "vagina", "dick", "cock", "penis", "loli", "shota", "child", "children", "sex", "fuck"]
-files = ["word"]
+files = ["word-blacklist.txt"]

--- a/config.toml
+++ b/config.toml
@@ -20,3 +20,4 @@ samplers = ["Euler a", "Euler", "DPM++ 2M Karras", "DPM++ SDE Karras", "DPM++ 2M
 
 [blacklist]
 words = ["nsfw", "nude", "naked", "pussy", "vagina", "dick", "cock", "penis", "loli", "shota", "child", "children", "sex", "fuck"]
+files = ["word"]

--- a/main.py
+++ b/main.py
@@ -130,7 +130,19 @@ class Bot:
             except Exception as e:
                 print(e)
 
-        blacklist = instance.config['blacklist']['words']
+        blacklist = set()
+        if 'words' in instance.config['blacklist']:
+            blacklist |= set(instance.config['blacklist']['words'])
+        if 'files' in instance.config['blacklist']:
+            for file in instance.config['blacklist']['files']:
+                try:
+                    with open(file, 'rt', encoding='utf8') as f:
+                        blacklist |= set(
+                            filter(lambda x: bool(x.strip()),
+                                   map(lambda x: x.removesuffix('\n'),
+                                       f.readlines())))
+                except IOError:
+                    pass  # Ignore failing files
         verbose = instance.general['verbose']
 
         PROMPT = instance.params["additional_prompt"].replace(", ", "`, `") + "`."

--- a/main.py
+++ b/main.py
@@ -97,7 +97,7 @@ class DFAWordBlacklist:
         return result
 
     def replace(self, value: str, replace: str):
-        single_chr = len(replace) != 1 or (
+        single_chr = len(replace) == 1 or (
             len(replace) == 2 and replace.startswith('\\'))
         result = ''
         matches = self.exec(value)
@@ -105,7 +105,7 @@ class DFAWordBlacklist:
         while matches:
             start, end = matches.pop(0)
             result += value[i:start]
-            result += replace if single_chr else (replace * (end - start))
+            result += (replace * (end - start)) if single_chr else replace
             i = end
         result += value[i:]
         return result

--- a/main.py
+++ b/main.py
@@ -97,14 +97,15 @@ class DFAWordBlacklist:
         return result
 
     def replace(self, value: str, replace: str):
+        single_chr = len(replace) != 1 or (
+            len(replace) == 2 and replace.startswith('\\'))
         result = ''
         matches = self.exec(value)
         i = 0
         while matches:
             start, end = matches.pop(0)
             result += value[i:start]
-            result += replace if len(replace) != 1 else (replace *
-                                                         (end - start))
+            result += replace if single_chr else (replace * (end - start))
             i = end
         result += value[i:]
         return result
@@ -217,7 +218,7 @@ class Animegen(commands.Bot, ABC):
                 # Generate the response
                 response = self.blacklist.replace(
                     await self.chat(f"{message.author.display_name}: {message.content}"),
-                    '*')
+                    '\\*')
 
             if match := re.search(r"\[image: ([^\]]*)\]", response, re.IGNORECASE):
                 await self.send_with_image(

--- a/word-blacklist.txt
+++ b/word-blacklist.txt
@@ -1,0 +1,14 @@
+nsfw
+nude
+naked
+pussy
+vagina
+dick
+cock
+penis
+loli
+shota
+child
+children
+sex
+fuck


### PR DESCRIPTION
Adds ability to use newline-seperated file wordlists as blacklists, which is easier for getting mass blacklists e.g. from internet.
Planning on also reworking the clensing algorithm to be more performant as it currently checks through *every* word in the blacklist (which does not make use of the hashing abilities of `set`). the advantages of `set` are, however, inaccessible without artificially limiting the filtering to full words, and not sub-words